### PR TITLE
fix for running on macOS with latest pandas

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 import matplotlib.pyplot as plt
 
 plt.style.use('seaborn-whitegrid')
-plt.rcParams['font.sans-serif'] = ['SimHei']
+plt.rcParams['font.sans-serif'] = ['SimHei', 'Arial Unicode MS']
 plt.rcParams['axes.unicode_minus'] = False
 
 theory_difficulty_decay = -0.7
@@ -184,7 +184,7 @@ if __name__ == "__main__":
                 request_recall) / np.log(0.9))
 
             if Reps == 1:
-                df_log = df_log.append({'Lapses': Lapses, 'Ivl': Ivl, 'Grade': Grade}, ignore_index=True)
+                df_log = pd.concat([df_log, pd.DataFrame.from_records([{'Lapses': Lapses, 'Ivl': Ivl, 'Grade': Grade}])])
 
         S_p_default = cal_stability_p_default(df_log, S_p_default)  # 自适应初始稳定性
 


### PR DESCRIPTION
1. macOS 下没有 SimHei 字体，增加 Arial Unicode MS 作为 fallback
2. 最新版本的 pandas 使用 [Dataframe.append](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.append.html) 已经被标记为 [deprecated](https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append)，使用 pandas.concat 代替