### PR TITLE
try to fix bug for globalData.stabilityDataArry

### DIFF
--- a/fsrs.js/fsrs.js
+++ b/fsrs.js/fsrs.js
@@ -96,8 +96,8 @@
             // Adaptive globalData.defaultStability
             if (lastReps === 1 && lastLapses === 0) {
                 globalData.stabilityDataArry.push({
-                    interval: interval,
-                    retrievability: grade === "0" ? 0 : 1
+                    interval: cardData.interval,
+                    retrievability: grade === 0 ? 0 : 1
                 });
 
                 if (globalData.stabilityDataArry.length > 0 && globalData.stabilityDataArry.length % 50 === 0) {

--- a/fsrs.js/package.json
+++ b/fsrs.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fsrs.js",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "FSRS (free spaced repetition scheduler) algorithm, based on the DSR model proposed by Piotr Wozniak, author of SuperMemo",
     "main": "fsrs.js",
     "scripts": {


### PR DESCRIPTION
@oflg There seems to be  a problem for pushing to `globalData.stabilityDataArry`

1. The type of `grade` is Number, so I think the check between grade and `"0"` will always false
2. I cannot found a definition of `interval`, I have found an assignment  at https://github.com/oflg/fishing/blob/v2.1.1/macros/fsrs.js#L76 , but I cannot understand the meaning ( I never use TiddlyWiki), I guess it may be cardData.interval?